### PR TITLE
Update dependencies

### DIFF
--- a/sample_maven/pom.xml
+++ b/sample_maven/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sample_maven/pom.xml
+++ b/sample_maven/pom.xml
@@ -26,8 +26,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/sample_maven/pom.xml
+++ b/sample_maven/pom.xml
@@ -24,7 +24,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>


### PR DESCRIPTION
## Update dependencies

- Use junit 4.13.2 (resolve a security warning)
- Require Java 8 source code (use a modern compiler)
- Use maven compiler plugin 3.8.1 (use latest release)
